### PR TITLE
Add early image prestage via GCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@
 ## Bootstrapping Example
 
 ```bash
-
+# Ad hoc scripts
 BRANCH=feat-docker-prestage
 curl -sSL -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/project-gnr8/instance-bootstrap/refs/heads/${BRANCH}/oneshot.sh | bash -s -- ubuntu 535 "aws_timestream_access_key='test_key' aws_timestream_secret_key='test_secret' aws_timestream_database='test_db' aws_timestream_region='test_region' environmentID='test_envid'" '["nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12"]' 'brev-image-prestage' ${BRANCH}
+
+# Ad hoc scripts
+INST_USER=jmorgan
+GCS_BUCKET=brev-image-prestage
+IMAGE_LIST_JSON='["nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12"]'
+
+/opt/instance-bootstrap/image-prestage.sh ${INST_USER} ${IMAGE_LIST_JSON} ${GCS_BUCKET}
+/opt/instance-bootstrap/image-import.sh ${INST_USER} /opt/prestage/docker-images-prestage-status.json /opt/prestage/docker-images
 
 ```
 
@@ -42,3 +50,120 @@ sudo systemctl reset-failed
 sudo pkill -f 'startup.sh'
 sudo pkill -f 'nvwb-cli'
 ```
+
+## Troubleshooting Docker Image Prestaging Service
+
+If you encounter issues with the Docker image prestaging service, follow these troubleshooting steps:
+
+### 1. Check Service Status
+
+```bash
+# Check if the service is active
+sudo systemctl status docker-image-prestage.service
+
+# View detailed service properties
+sudo systemctl show docker-image-prestage.service
+
+# Check if the service is enabled
+sudo systemctl is-enabled docker-image-prestage.service
+```
+
+### 2. Review Service Logs
+
+```bash
+# View all logs for the service
+sudo journalctl -u docker-image-prestage.service
+
+# View only the most recent logs
+sudo journalctl -u docker-image-prestage.service -n 50
+
+# Follow logs in real-time
+sudo journalctl -u docker-image-prestage.service -f
+```
+
+### 3. Check Environment Configuration
+
+```bash
+# Verify environment file exists and has correct permissions
+ls -la /etc/systemd/docker-image-prestage.env
+
+# Check environment file contents
+sudo cat /etc/systemd/docker-image-prestage.env
+
+# Verify the IMAGE_LIST_JSON format is correct (should be properly quoted)
+```
+
+### 4. Check Status File
+
+```bash
+# View the current status file
+cat /opt/prestage/docker-images-prestage-status.json
+
+# If status is stuck at "downloading", manually update it (replace values as needed)
+echo '{"status":"completed","completed":1,"total":1,"images":["nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12"]}' | sudo tee /opt/prestage/docker-images-prestage-status.json
+```
+
+### 5. Verify Script Permissions and Execution
+
+```bash
+# Check if scripts are executable
+ls -la /opt/instance-bootstrap/image-prestage.sh
+ls -la /opt/instance-bootstrap/image-import.sh
+
+# Make scripts executable if needed
+sudo chmod +x /opt/instance-bootstrap/image-prestage.sh
+sudo chmod +x /opt/instance-bootstrap/image-import.sh
+
+# Run the prestage script manually for testing
+sudo /opt/instance-bootstrap/image-prestage.sh ubuntu '["nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12"]' brev-image-prestage
+```
+
+### 6. Check for Directory and Permission Issues
+
+```bash
+# Verify prestage directories exist with correct permissions
+ls -la /opt/prestage/
+ls -la /opt/prestage/docker-images/
+
+# Create directories if missing
+sudo mkdir -p /opt/prestage/docker-images
+sudo chmod 775 /opt/prestage /opt/prestage/docker-images
+sudo chown ubuntu:ubuntu /opt/prestage /opt/prestage/docker-images
+```
+
+### 7. Restart the Service
+
+```bash
+# Reload systemd configuration
+sudo systemctl daemon-reload
+
+# Restart the service
+sudo systemctl restart docker-image-prestage.service
+```
+
+### 8. Common Issues and Solutions
+
+1. **Service inactive despite being enabled**
+   - Check for syntax errors in the service file
+   - Verify the ExecStart path is correct
+   - Ensure all required directories exist
+
+2. **Status file stuck at "downloading"**
+   - The script may have terminated prematurely
+   - Check for errors in the logs
+   - Manually update the status file if needed
+
+3. **Permission denied errors**
+   - Ensure scripts are executable
+   - Check ownership of directories and files
+   - Verify the service is running as the correct user
+
+4. **Network-related failures**
+   - Verify connectivity to the GCS signed URL service
+   - Check if the GCS bucket exists and is accessible
+   - Ensure Docker service is running properly
+
+5. **JSON parsing errors**
+   - Verify the IMAGE_LIST_JSON format in the environment file
+   - Ensure proper quoting of the JSON string
+   - Check for syntax errors in the JSON

--- a/README.md
+++ b/README.md
@@ -24,10 +24,14 @@ IMAGE_LIST_JSON='["nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12"]'
 # Stop and disable services
 sudo systemctl stop instance-oneshot.service workbench-install.service
 sudo systemctl disable instance-oneshot.service workbench-install.service
+sudo systemctl stop docker-image-prestage.service
+sudo systemctl disable docker-image-prestage.service
+
 
 # Remove service files
 sudo rm -f /etc/systemd/system/instance-oneshot.service
 sudo rm -f /etc/systemd/system/workbench-install.service
+sudo rm -f /etc/systemd/system/docker-image-prestage.service
 
 # Remove installed scripts
 sudo rm -f /opt/startup.sh

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 ## Bootstrapping Example
 
 ```bash
-curl -sSL -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/project-gnr8/instance-bootstrap/refs/heads/feat-docker-prestage/oneshot.sh | bash -s -- ubuntu 535 "aws_timestream_access_key='test_key' aws_timestream_secret_key='test_secret' aws_timestream_database='test_db' aws_timestream_region='test_region' environmentID='test_envid'" '["nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12"]' 'brev-image-prestage' 'feat-docker-prestage'
+
+BRANCH=feat-docker-prestage
+curl -sSL -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/project-gnr8/instance-bootstrap/refs/heads/${BRANCH}/oneshot.sh | bash -s -- ubuntu 535 "aws_timestream_access_key='test_key' aws_timestream_secret_key='test_secret' aws_timestream_database='test_db' aws_timestream_region='test_region' environmentID='test_envid'" '["nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12"]' 'brev-image-prestage' ${BRANCH}
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ sudo rm -f /opt/startup.sh
 sudo rm -f $HOME/.nvwb/install.sh
 sudo rm -rf $HOME/.nvwb/*
 
+# Remove prestaging files
+sudo rm -rf /opt/prestage
+
 # Clear journal logs
 sudo journalctl --rotate
 sudo journalctl --vacuum-time=1s

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ sudo rm -f /etc/systemd/system/docker-image-prestage.service
 sudo rm -f /opt/startup.sh
 sudo rm -f $HOME/.nvwb/install.sh
 sudo rm -rf $HOME/.nvwb/*
+sudo rm -rf /opt/instance-bootstrap
 
 # Remove prestaging files
 sudo rm -rf /opt/prestage

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 BRANCH=feat-docker-prestage
 curl -sSL -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/project-gnr8/instance-bootstrap/refs/heads/${BRANCH}/oneshot.sh | bash -s -- ubuntu 535 "aws_timestream_access_key='test_key' aws_timestream_secret_key='test_secret' aws_timestream_database='test_db' aws_timestream_region='test_region' environmentID='test_envid'" '["nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12"]' 'brev-image-prestage' ${BRANCH}
 
-
 ```
 
 ## Resource Cleanup

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 ## Bootstrapping Example
 
 ```bash
-curl -sSL -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/project-gnr8/instance-bootstrap/refs/heads/main/oneshot.sh | bash -s -- ubuntu 535 "aws_timestream_access_key='test_key' aws_timestream_secret_key='test_secret' aws_timestream_database='test_db' aws_timestream_region='test_region' environmentID='test_envid'"
+curl -sSL -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/project-gnr8/instance-bootstrap/refs/heads/feat-docker-prestage/oneshot.sh | bash -s -- ubuntu 535 "aws_timestream_access_key='test_key' aws_timestream_secret_key='test_secret' aws_timestream_database='test_db' aws_timestream_region='test_region' environmentID='test_envid'" '["nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12"]' 'brev-image-prestage' 'feat-docker-prestage'
+
+
 ```
 
 ## Resource Cleanup

--- a/docker-image-prestage.service
+++ b/docker-image-prestage.service
@@ -7,12 +7,13 @@ Requires=docker.service
 [Service]
 Type=oneshot
 EnvironmentFile=/etc/systemd/docker-image-prestage.env
-ExecStart=/opt/instance-bootstrap/image-prestage.sh ${INST_USER} ${IMAGE_LIST_JSON} ${GCS_BUCKET}
-StandardOutput=journal
-StandardError=journal
+ExecStart=/bin/bash -c 'echo "Starting Docker image prestaging at $(date)" && /opt/instance-bootstrap/image-prestage.sh ${INST_USER} "${IMAGE_LIST_JSON}" ${GCS_BUCKET}'
+StandardOutput=journal+console
+StandardError=journal+console
 KillMode=process
-TimeoutStartSec=0
+TimeoutStartSec=3600
 RemainAfterExit=yes
+WorkingDirectory=/opt/instance-bootstrap
 
 [Install]
 WantedBy=multi-user.target

--- a/docker-image-prestage.service
+++ b/docker-image-prestage.service
@@ -1,19 +1,25 @@
 [Unit]
 Description=Docker Image Prestaging Service
-After=network-online.target docker.service
-Wants=network-online.target
-Requires=docker.service
+After=docker.service network-online.target
+Requires=docker.service network-online.target
 
 [Service]
 Type=oneshot
 EnvironmentFile=/etc/systemd/docker-image-prestage.env
+WorkingDirectory=/opt/instance-bootstrap
+# Use bash -c with set -e removed to prevent premature exits
 ExecStart=/bin/bash -c 'echo "Starting Docker image prestaging at $(date)" && /opt/instance-bootstrap/image-prestage.sh ${INST_USER} ${IMAGE_LIST_JSON} ${GCS_BUCKET}'
+# Increase timeout to allow for long downloads
+TimeoutStartSec=3600
+# Ensure proper permissions for the prestage directory
+ExecStartPre=/bin/bash -c 'mkdir -p /opt/prestage/docker-images && chown -R ${INST_USER}:${INST_USER} /opt/prestage'
+# Ensure the script is executable
+ExecStartPre=/bin/bash -c 'chmod +x /opt/instance-bootstrap/image-prestage.sh'
+# Don't restart on failure
+Restart=no
+# Send output to both journal and console
 StandardOutput=journal+console
 StandardError=journal+console
-KillMode=process
-TimeoutStartSec=3600
-RemainAfterExit=yes
-WorkingDirectory=/opt/instance-bootstrap
 
 [Install]
 WantedBy=multi-user.target

--- a/docker-image-prestage.service
+++ b/docker-image-prestage.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Docker Image Prestaging Service
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/systemd/docker-image-prestage.env
+ExecStart=/opt/image-prestage.sh ${INST_USER} ${IMAGE_LIST_JSON} ${GCS_BUCKET}
+StandardOutput=journal
+StandardError=journal
+KillMode=process
+TimeoutStartSec=0
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/docker-image-prestage.service
+++ b/docker-image-prestage.service
@@ -7,7 +7,7 @@ Requires=docker.service
 [Service]
 Type=oneshot
 EnvironmentFile=/etc/systemd/docker-image-prestage.env
-ExecStart=/opt/image-prestage.sh ${INST_USER} ${IMAGE_LIST_JSON} ${GCS_BUCKET}
+ExecStart=/opt/instance-bootstrap/image-prestage.sh ${INST_USER} ${IMAGE_LIST_JSON} ${GCS_BUCKET}
 StandardOutput=journal
 StandardError=journal
 KillMode=process

--- a/docker-image-prestage.service
+++ b/docker-image-prestage.service
@@ -7,7 +7,7 @@ Requires=docker.service
 [Service]
 Type=oneshot
 EnvironmentFile=/etc/systemd/docker-image-prestage.env
-ExecStart=/bin/bash -c 'echo "Starting Docker image prestaging at $(date)" && /opt/instance-bootstrap/image-prestage.sh ${INST_USER} "${IMAGE_LIST_JSON}" ${GCS_BUCKET}'
+ExecStart=/bin/bash -c 'echo "Starting Docker image prestaging at $(date)" && /opt/instance-bootstrap/image-prestage.sh ${INST_USER} ${IMAGE_LIST_JSON} ${GCS_BUCKET}'
 StandardOutput=journal+console
 StandardError=journal+console
 KillMode=process

--- a/image-import.sh
+++ b/image-import.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+# Enable strict mode
+set -euo pipefail
+
+# Parse command line arguments
+INST_USER=$1
+STATUS_FILE=${2:-"/opt/prestage/docker-images-prestage-status.json"}
+PRESTAGE_DIR=${3:-"/opt/prestage/docker-images"}
+
+user_home=$(eval echo ~$INST_USER)
+LOG_FILE=${LOG_FILE:-"$user_home/.verb-setup.log"}
+
+# Initialize log file
+init_log_file() {
+    local log_dir=$(dirname "$LOG_FILE")
+    if [ ! -d "$log_dir" ]; then
+        sudo mkdir -p "$log_dir" 2>/dev/null
+        sudo chmod 775 "$log_dir"
+    fi
+    
+    sudo touch "$LOG_FILE" 2>/dev/null
+    sudo chmod 644 "$LOG_FILE"
+    sudo chown "$INST_USER":"$INST_USER" "$LOG_FILE"
+    echo "[$( date +"%Y-%m-%dT%H:%M:%S%z" )] [INFO] Log initialized at $LOG_FILE" >> "$LOG_FILE"
+}
+
+# Enhanced logging function with ISO 8601 timestamps
+echo_info() {
+    local timestamp=$(date +"%Y-%m-%dT%H:%M:%S%z")
+    # Format for console with colors
+    printf "\033[1;34m[INFO]\033[0m [%s] %s\n" "$timestamp" "$1" >&1
+    # Format for log file (without colors)
+    printf "[%s] [INFO] %s\n" "$timestamp" "$1" >> "$LOG_FILE"
+}
+
+echo_error() {
+    local timestamp=$(date +"%Y-%m-%dT%H:%M:%S%z")
+    # Format for console with colors
+    printf "\033[1;31m[ERROR]\033[0m [%s] %s\n" "$timestamp" "$1" >&1
+    # Format for log file (without colors)
+    printf "[%s] [ERROR] %s\n" "$timestamp" "$1" >> "$LOG_FILE"
+}
+
+echo_success() {
+    local timestamp=$(date +"%Y-%m-%dT%H:%M:%S%z")
+    # Format for console with colors
+    printf "\033[1;32m[SUCCESS]\033[0m [%s] %s\n" "$timestamp" "$1" >&1
+    # Format for log file (without colors)
+    printf "[%s] [SUCCESS] %s\n" "$timestamp" "$1" >> "$LOG_FILE"
+}
+
+# Check if Docker is running
+check_docker() {
+    echo_info "Checking if Docker is running..."
+    if ! docker info &>/dev/null; then
+        echo_error "Docker is not running. Please ensure Docker service is active."
+        return 1
+    fi
+    echo_info "Docker is running correctly."
+    return 0
+}
+
+# Import images from tar files
+import_images() {
+    echo_info "Starting Docker image import process..."
+    
+    # Check if status file exists
+    if [ ! -f "$STATUS_FILE" ]; then
+        echo_error "Status file not found: $STATUS_FILE"
+        return 1
+    fi
+    
+    # Check if prestage directory exists
+    if [ ! -d "$PRESTAGE_DIR" ]; then
+        echo_error "Prestage directory not found: $PRESTAGE_DIR"
+        return 1
+    fi
+    
+    # Check status
+    local status=$(jq -r '.status' "$STATUS_FILE" 2>/dev/null || echo "unknown")
+    if [ "$status" != "completed" ] && [ "$status" != "completed_with_errors" ]; then
+        echo_error "Image prestaging not completed. Current status: $status"
+        return 1
+    fi
+    
+    # Get image list
+    local images=$(jq -r '.images | .[]' "$STATUS_FILE")
+    local total=$(jq -r '.total' "$STATUS_FILE")
+    local completed=0
+    local failed=0
+    
+    echo_info "Found $total images to import"
+    
+    # Process each image
+    for image in $images; do
+        # Convert image name to a valid filename
+        local safe_name=$(echo "$image" | tr '/:' '_-')
+        local tar_file="$PRESTAGE_DIR/${safe_name}.tar"
+        
+        if [ -f "$tar_file" ]; then
+            echo_info "Importing image: $image from $tar_file"
+            if docker load -i "$tar_file"; then
+                echo_success "Successfully imported image: $image"
+                ((completed++))
+            else
+                echo_error "Failed to import image: $image"
+                ((failed++))
+            fi
+        else
+            echo_error "Tar file not found for image: $image (expected at $tar_file)"
+            ((failed++))
+        fi
+    done
+    
+    # Final status update
+    if [ $failed -gt 0 ]; then
+        echo_error "$failed out of $total imports failed"
+        return 1
+    else
+        echo_success "All $total images imported successfully"
+        return 0
+    fi
+}
+
+# Main function
+main() {
+    echo_info "Starting Docker image import process"
+    
+    # Initialize log file
+    init_log_file
+    
+    # Check Docker
+    check_docker || exit 1
+    
+    # Import images
+    import_images
+    
+    echo_info "Docker image import process completed"
+}
+
+# Execute main function
+main

--- a/image-import.sh
+++ b/image-import.sh
@@ -114,13 +114,15 @@ check_docker() {
 # Get the correct tar filename for an image
 get_tar_filename() {
     local image=$1
-    local safe_name=$(echo "$image" | tr '/:' '_-')
     
     # Check if we have a custom mapping for this image
     if [[ -n "${IMAGE_TO_OBJECT_MAP[$image]:-}" ]]; then
-        echo "$PRESTAGE_DIR/${safe_name}.tar"
+        # Use the object name directly as the filename
+        local object_name="${IMAGE_TO_OBJECT_MAP[$image]}"
+        echo "$PRESTAGE_DIR/$object_name"
     else
-        # Use the default naming convention
+        # Fallback to the default naming convention
+        local safe_name=$(echo "$image" | tr '/:' '_-')
         echo "$PRESTAGE_DIR/${safe_name}.tar"
     fi
 }

--- a/image-prestage.sh
+++ b/image-prestage.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+
+# Enable strict mode
+set -euo pipefail
+
+# Parse command line arguments
+INST_USER=$1
+IMAGE_LIST_JSON=$2
+GCS_BUCKET=${3:-"docker-images-prestage"}
+
+# Define constants and paths
+PRESTAGE_DIR="/opt/prestage/docker-images"
+STATUS_FILE="/opt/prestage/docker-images-prestage-status.json"
+
+user_home=$(eval echo ~$INST_USER)
+LOG_FILE=${LOG_FILE:-"$user_home/.verb-setup.log"}
+
+PARALLEL_DOWNLOADS=4
+
+# Initialize log file
+init_log_file() {
+    local log_dir=$(dirname "$LOG_FILE")
+    if [ ! -d "$log_dir" ]; then
+        sudo mkdir -p "$log_dir" 2>/dev/null
+        sudo chmod 775 "$log_dir"
+    fi
+    
+    sudo touch "$LOG_FILE" 2>/dev/null
+    sudo chmod 644 "$LOG_FILE"
+    sudo chown "$INST_USER":"$INST_USER" "$LOG_FILE"
+    echo "[$( date +"%Y-%m-%dT%H:%M:%S%z" )] [INFO] Log initialized at $LOG_FILE" >> "$LOG_FILE"
+}
+
+# Enhanced logging function with ISO 8601 timestamps
+echo_info() {
+    local timestamp=$(date +"%Y-%m-%dT%H:%M:%S%z")
+    # Format for console with colors
+    printf "\033[1;34m[INFO]\033[0m [%s] %s\n" "$timestamp" "$1" >&1
+    # Format for log file (without colors)
+    printf "[%s] [INFO] %s\n" "$timestamp" "$1" >> "$LOG_FILE"
+}
+
+echo_error() {
+    local timestamp=$(date +"%Y-%m-%dT%H:%M:%S%z")
+    # Format for console with colors
+    printf "\033[1;31m[ERROR]\033[0m [%s] %s\n" "$timestamp" "$1" >&1
+    # Format for log file (without colors)
+    printf "[%s] [ERROR] %s\n" "$timestamp" "$1" >> "$LOG_FILE"
+}
+
+echo_success() {
+    local timestamp=$(date +"%Y-%m-%dT%H:%M:%S%z")
+    # Format for console with colors
+    printf "\033[1;32m[SUCCESS]\033[0m [%s] %s\n" "$timestamp" "$1" >&1
+    # Format for log file (without colors)
+    printf "[%s] [SUCCESS] %s\n" "$timestamp" "$1" >> "$LOG_FILE"
+}
+
+# Install GCS client with retry logic
+install_gcs_client() {
+    echo_info "Installing Google Cloud SDK for GCS access..."
+    
+    if command -v gsutil &>/dev/null; then
+        echo_info "Google Cloud SDK already installed."
+        return 0
+    fi
+    
+    # Add the Cloud SDK distribution URI as a package source
+    echo_info "Adding Google Cloud SDK repository..."
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
+        sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list > /dev/null
+    
+    # Import the Google Cloud public key
+    echo_info "Importing Google Cloud SDK keys..."
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+        sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - > /dev/null
+    
+    # Update and install the Cloud SDK
+    echo_info "Installing Google Cloud SDK packages..."
+    sudo apt-get update -y > /dev/null
+    sudo apt-get install -y google-cloud-sdk-gcs-auth-only > /dev/null
+    
+    echo_success "Google Cloud SDK installed successfully."
+}
+
+# Prepare the staging directory
+prepare_staging_dir() {
+    echo_info "Preparing image staging directory: $PRESTAGE_DIR"
+    
+    # Create parent directory if it doesn't exist
+    local parent_dir=$(dirname "$PRESTAGE_DIR")
+    if [ ! -d "$parent_dir" ]; then
+        sudo mkdir -p "$parent_dir"
+        sudo chmod 775 "$parent_dir"
+        sudo chown "$INST_USER":"$INST_USER" "$parent_dir"
+    fi
+    
+    # Create image directory if it doesn't exist
+    if [ ! -d "$PRESTAGE_DIR" ]; then
+        sudo mkdir -p "$PRESTAGE_DIR"
+        sudo chmod 775 "$PRESTAGE_DIR"
+        sudo chown "$INST_USER":"$INST_USER" "$PRESTAGE_DIR"
+    fi
+    
+    # Create status file directory if it doesn't exist
+    local status_dir=$(dirname "$STATUS_FILE")
+    if [ ! -d "$status_dir" ]; then
+        sudo mkdir -p "$status_dir"
+        sudo chmod 775 "$status_dir"
+        sudo chown "$INST_USER":"$INST_USER" "$status_dir"
+    fi
+    
+    # Initialize status file
+    echo '{"status":"initializing","completed":0,"total":0,"images":[]}' | sudo tee "$STATUS_FILE" > /dev/null
+    sudo chmod 644 "$STATUS_FILE"
+    sudo chown "$INST_USER":"$INST_USER" "$STATUS_FILE"
+}
+
+# Parse image list and prepare for download
+parse_image_list() {
+    echo_info "Parsing image list..."
+    
+    # Default image if none provided
+    if [ -z "$IMAGE_LIST_JSON" ]; then
+        IMAGE_LIST_JSON='["nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12"]'
+    fi
+    
+    # Count total images
+    local total_images=$(echo "$IMAGE_LIST_JSON" | jq '. | length')
+    echo_info "Found $total_images images to process"
+    
+    # Update status file
+    echo "{\"status\":\"downloading\",\"completed\":0,\"total\":$total_images,\"images\":$IMAGE_LIST_JSON}" | sudo tee "$STATUS_FILE" > /dev/null
+}
+
+# Download images from GCS with parallel processing
+download_images() {
+    echo_info "Starting parallel image downloads from GCS bucket: $GCS_BUCKET"
+    
+    # Get image list from status file
+    local images=$(jq -r '.images | .[]' "$STATUS_FILE")
+    local total=$(jq -r '.total' "$STATUS_FILE")
+    local completed=0
+    local failed=0
+    local image_files=()
+    
+    # Process each image
+    for image in $images; do
+        # Convert image name to a valid filename
+        local safe_name=$(echo "$image" | tr '/:' '_-')
+        local tar_file="$PRESTAGE_DIR/${safe_name}.tar"
+        local gcs_path="gs://$GCS_BUCKET/${safe_name}.tar"
+        
+        image_files+=("$tar_file")
+        echo_info "Queuing download for image: $image (from $gcs_path)"
+    done
+    
+    # Use GNU Parallel to download multiple files concurrently
+    if [ ${#image_files[@]} -gt 0 ]; then
+        echo_info "Starting parallel downloads with $PARALLEL_DOWNLOADS concurrent jobs"
+        
+        # Create a temporary file with download commands
+        local cmd_file=$(mktemp)
+        local i=0
+        
+        for image in $images; do
+            local safe_name=$(echo "$image" | tr '/:' '_-')
+            local tar_file="$PRESTAGE_DIR/${safe_name}.tar"
+            local gcs_path="gs://$GCS_BUCKET/${safe_name}.tar"
+            
+            echo "gsutil -o GSUtil:parallel_composite_upload_threshold=150M -m cp \"$gcs_path\" \"$tar_file\" && echo \"SUCCESS:$image\" || echo \"FAILED:$image\"" >> "$cmd_file"
+            ((i++))
+        done
+        
+        # Install GNU Parallel if not present
+        if ! command -v parallel &>/dev/null; then
+            echo_info "Installing GNU Parallel for concurrent downloads..."
+            sudo apt-get update -y > /dev/null
+            sudo apt-get install -y parallel > /dev/null
+        fi
+        
+        # Run downloads in parallel and capture results
+        parallel --jobs "$PARALLEL_DOWNLOADS" --bar < "$cmd_file" | while read -r result; do
+            if [[ "$result" == SUCCESS:* ]]; then
+                image="${result#SUCCESS:}"
+                echo_success "Successfully downloaded image: $image"
+                ((completed++))
+                # Update status file with progress
+                jq --arg completed "$completed" '.completed = ($completed|tonumber)' "$STATUS_FILE" | sudo tee "$STATUS_FILE.tmp" > /dev/null
+                sudo mv "$STATUS_FILE.tmp" "$STATUS_FILE"
+            elif [[ "$result" == FAILED:* ]]; then
+                image="${result#FAILED:}"
+                echo_error "Failed to download image: $image"
+                ((failed++))
+            fi
+        done
+        
+        # Clean up
+        rm -f "$cmd_file"
+    fi
+    
+    # Final status update
+    if [ $failed -gt 0 ]; then
+        echo_error "$failed out of $total downloads failed"
+        echo "{\"status\":\"completed_with_errors\",\"completed\":$completed,\"total\":$total,\"failed\":$failed,\"images\":$(jq '.images' "$STATUS_FILE")}" | sudo tee "$STATUS_FILE" > /dev/null
+        return 1
+    else
+        echo_success "All $total images downloaded successfully"
+        echo "{\"status\":\"completed\",\"completed\":$total,\"total\":$total,\"failed\":0,\"images\":$(jq '.images' "$STATUS_FILE")}" | sudo tee "$STATUS_FILE" > /dev/null
+        return 0
+    fi
+}
+
+# Main function
+main() {
+    echo_info "Starting Docker image prestaging process"
+    
+    # Initialize log file
+    init_log_file
+    
+    # Install GCS client
+    install_gcs_client
+    
+    # Prepare staging directory
+    prepare_staging_dir
+    
+    # Parse image list
+    parse_image_list
+    
+    # Download images
+    download_images
+    
+    echo_info "Docker image prestaging process completed"
+}
+
+# Execute main function
+main

--- a/image-prestage.sh
+++ b/image-prestage.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # Parse command line arguments
 INST_USER=$1
 IMAGE_LIST_JSON=$2
-GCS_BUCKET=${3:-"docker-images-prestage"}
+GCS_BUCKET=${3:-"brev-image-prestage"}
 
 # Define constants and paths
 PRESTAGE_DIR="/opt/prestage/docker-images"

--- a/image-prestage.sh
+++ b/image-prestage.sh
@@ -252,6 +252,32 @@ download_images() {
     fi
 }
 
+# Check for required tools
+check_required_tools() {
+    echo_info "Checking for required tools..."
+    
+    # Define required commands
+    local required_commands=("curl" "jq" "aria2c")
+    local missing_commands=()
+    
+    # Check each command
+    for cmd in "${required_commands[@]}"; do
+        if ! command -v "$cmd" &>/dev/null; then
+            missing_commands+=("$cmd")
+        fi
+    done
+    
+    # Report missing commands
+    if [ ${#missing_commands[@]} -gt 0 ]; then
+        echo_error "Missing required tools: ${missing_commands[*]}"
+        echo_error "Please run oneshot.sh first to install required dependencies."
+        return 1
+    fi
+    
+    echo_info "All required tools are available"
+    return 0
+}
+
 # Main function
 main() {
     echo_info "Starting Docker image prestaging process"
@@ -260,12 +286,7 @@ main() {
     init_log_file
     
     # Check for required tools
-    for cmd in curl jq aria2c; do
-        if ! command -v $cmd &>/dev/null; then
-            echo_error "Required tool '$cmd' is not installed. Please run oneshot.sh first."
-            exit 1
-        fi
-    done
+    check_required_tools || exit 1
     
     # Prepare staging directory
     prepare_staging_dir

--- a/oneshot.sh
+++ b/oneshot.sh
@@ -3,18 +3,37 @@
 # Enable debug mode to see what's happening
 set -x
 
-# Parse command line arguments
+# Define variables
 INST_USER=$1
 INST_DRIVER=$2
 # Pass the metrics variables as a single string without adding extra quotes
 INST_METRICS_VARS="$3"
+# Pass the image list as a JSON string
+IMAGE_LIST_JSON=${4:-'["nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12"]'}
+# GCS bucket for image storage
+GCS_BUCKET=${5:-"docker-images-prestage"}
+# Repository URL and branch for cloning
+REPO_URL=${6:-"https://github.com/project-gnr8/instance-bootstrap.git"}
+REPO_BRANCH=${7:-"main"}
+
+# Define constants
+SERVICE_NAME="instance-oneshot"
+SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+
+ENV_FILE="/etc/systemd/system/${SERVICE_NAME}.env"
+PRESTAGE_SERVICE_NAME="docker-image-prestage"
+PRESTAGE_SERVICE_FILE="/etc/systemd/system/${PRESTAGE_SERVICE_NAME}.service"
+PRESTAGE_ENV_FILE="/etc/systemd/${PRESTAGE_SERVICE_NAME}.env"
+SCRIPTS_DIR="/opt/instance-bootstrap"
+PRESTAGE_SCRIPT="$SCRIPTS_DIR/image-prestage.sh"
+IMPORT_SCRIPT="$SCRIPTS_DIR/image-import.sh"
+PRESTAGE_STATUS_FILE="/opt/prestage/docker-images-prestage-status.json"
+PRESTAGE_DIR="/opt/prestage/docker-images"
 
 # Define log file path and key variables
 user_home=$(eval echo ~$INST_USER)
 LOG_FILE=${LOG_FILE:-"$user_home/.verb-setup.log"}
 STARTUP_SCRIPT_URL=${STARTUP_SCRIPT_URL:-"https://raw.githubusercontent.com/project-gnr8/instance-bootstrap/refs/heads/main/startup.sh"}
-SERVICE_NAME="instance-oneshot"
-SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
 
 # Function to initialize log file and directory
 init_log_file() {
@@ -98,46 +117,217 @@ check_service_status() {
     return 1
 }
 
+# Check if prestage service is configured
+is_prestage_service_configured() {
+    # Check if service file exists
+    if [ ! -f "$PRESTAGE_SERVICE_FILE" ]; then
+        return 1
+    fi
+    
+    # Check if service is enabled
+    if ! systemctl is-enabled "$PRESTAGE_SERVICE_NAME" &>/dev/null; then
+        return 1
+    fi
+    
+    # Check if environment file exists
+    if [ ! -f "$PRESTAGE_ENV_FILE" ]; then
+        return 1
+    fi
+    
+    return 0
+}
+
+# Check if prestage scripts are installed
+is_prestage_scripts_installed() {
+    # Check if prestage script exists
+    if [ ! -f "$PRESTAGE_SCRIPT" ]; then
+        return 1
+    fi
+    
+    # Check if import script exists
+    if [ ! -f "$IMPORT_SCRIPT" ]; then
+        return 1
+    fi
+    
+    # Check if scripts are executable
+    if [ ! -x "$PRESTAGE_SCRIPT" ] || [ ! -x "$IMPORT_SCRIPT" ]; then
+        return 1
+    fi
+    
+    return 0
+}
+
+# Download a file from a URL
+download_file() {
+    local url=$1
+    local destination=$2
+    local description=$3
+    
+    if [ -z "$url" ]; then
+        echo_info "No URL provided for $description. Skipping download."
+        return 0
+    fi
+    
+    echo_info "Downloading $description from $url to $destination"
+    
+    # Create directory if it doesn't exist
+    local dir=$(dirname "$destination")
+    if [ ! -d "$dir" ]; then
+        sudo mkdir -p "$dir"
+    fi
+    
+    # Download the file
+    if [[ "$url" == gs://* ]]; then
+        # GCS URL
+        if ! command -v gsutil &> /dev/null; then
+            echo_info "gsutil not found. Installing Google Cloud SDK..."
+            curl -sSL https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir=/tmp/google-cloud-sdk > /dev/null
+            export PATH=$PATH:/tmp/google-cloud-sdk/bin
+        fi
+        sudo gsutil cp "$url" "$destination"
+    else
+        # HTTP/HTTPS URL
+        sudo curl -sSL "$url" -o "$destination"
+    fi
+    
+    # Set permissions
+    sudo chmod 755 "$destination"
+    
+    echo_info "$description downloaded successfully"
+    return 0
+}
+
+# Clone repository and stage scripts
+clone_and_stage_scripts() {
+    local repo_url=$1
+    local branch=$2
+    
+    if [ -z "$repo_url" ]; then
+        echo_info "No repository URL provided. Skipping clone operation."
+        return 0
+    fi
+    
+    echo_info "Cloning repository from $repo_url (branch: $branch)"
+    
+    # Install git if not available
+    if ! command -v git &>/dev/null; then
+        echo_info "Git not found. Installing..."
+        sudo apt-get update -y > /dev/null
+        sudo apt-get install -y git > /dev/null
+    fi
+    
+    # Remove existing directory if it exists to ensure clean clone
+    if [ -d "$SCRIPTS_DIR" ]; then
+        echo_info "Removing existing scripts directory"
+        sudo rm -rf "$SCRIPTS_DIR"
+    fi
+    
+    # Clone the repository
+    echo_info "Cloning repository to $SCRIPTS_DIR"
+    sudo git clone --depth 1 --branch "$branch" "$repo_url" "$SCRIPTS_DIR" 2>/dev/null || 
+        sudo git clone --depth 1 "$repo_url" "$SCRIPTS_DIR"
+    
+    if [ $? -ne 0 ]; then
+        echo_error "Failed to clone repository. Falling back to local scripts."
+        return 1
+    fi
+    
+    # Make all shell scripts executable
+    echo_info "Making scripts executable"
+    sudo find "$SCRIPTS_DIR" -name "*.sh" -exec chmod 777 {} \;
+    
+    # Make service files readable
+    sudo find "$SCRIPTS_DIR" -name "*.service" -exec chmod 644 {} \;
+    
+    echo_info "Scripts staged successfully from repository"
+    return 0
+}
+
+# Setup the image prestaging service
+setup_prestage_service() {
+    echo_info "Setting up Docker image prestaging service"
+    
+    # Check if all required files exist
+    if [ ! -f "$PRESTAGE_SCRIPT" ] || [ ! -f "$IMPORT_SCRIPT" ]; then
+        echo_error "Missing required scripts for image prestaging. Skipping service setup."
+        return 1
+    fi
+    
+    # Create environment file with variables
+    echo_info "Creating environment file for prestaging service"
+    echo "INST_USER=${INST_USER}" | sudo tee "$PRESTAGE_ENV_FILE" > /dev/null
+    echo "IMAGE_LIST_JSON='${IMAGE_LIST_JSON}'" | sudo tee -a "$PRESTAGE_ENV_FILE" > /dev/null
+    echo "GCS_BUCKET=${GCS_BUCKET}" | sudo tee -a "$PRESTAGE_ENV_FILE" > /dev/null
+    sudo chmod 600 "$PRESTAGE_ENV_FILE"
+    
+    # Create prestage directory if it doesn't exist
+    local prestage_dir="/opt/prestage"
+    if [ ! -d "$prestage_dir" ]; then
+        echo_info "Creating prestage directory: $prestage_dir"
+        sudo mkdir -p "$prestage_dir"
+        sudo chmod 775 "$prestage_dir"
+        sudo chown "$INST_USER":"$INST_USER" "$prestage_dir"
+    fi
+    
+    # Copy service file if it exists in the scripts directory
+    if [ -f "$SCRIPTS_DIR/docker-image-prestage.service" ]; then
+        echo_info "Copying prestage service file"
+        sudo cp "$SCRIPTS_DIR/docker-image-prestage.service" "$PRESTAGE_SERVICE_FILE"
+    fi
+    
+    # Check if service file exists
+    if [ ! -f "$PRESTAGE_SERVICE_FILE" ]; then
+        echo_error "Missing service file for image prestaging. Skipping service setup."
+        return 1
+    fi
+    
+    # Reload systemd, enable and start the service
+    echo_info "Reloading systemd configuration"
+    sudo systemctl daemon-reload
+    
+    # Enable but don't start the service yet
+    echo_info "Enabling $PRESTAGE_SERVICE_NAME service"
+    sudo systemctl enable "$PRESTAGE_SERVICE_NAME"
+    
+    # Start the service in a completely non-blocking way
+    echo_info "Starting $PRESTAGE_SERVICE_NAME service in background"
+    (sudo systemctl start "$PRESTAGE_SERVICE_NAME" &)
+    
+    echo_info "Docker image prestaging service started in the background"
+}
+
 # Setup and start the systemd service
 setup_service() {
-    echo_info "Setting up $SERVICE_NAME service"
+    echo_info "Setting up instance oneshot service"
     
-    # Create environment file with sensitive variables
-    local env_file="/etc/systemd/$SERVICE_NAME.env"
-    echo_info "Creating environment file for service variables"
-    echo "INST_USER=${INST_USER}" | sudo tee "$env_file" > /dev/null
-    echo "INST_DRIVER=${INST_DRIVER}" | sudo tee -a "$env_file" > /dev/null
-    echo "INST_METRICS_VARS=${INST_METRICS_VARS}" | sudo tee -a "$env_file" > /dev/null
-    sudo chmod 600 "$env_file"
-    
-    # Download the startup script
-    echo_info "Downloading startup script from $STARTUP_SCRIPT_URL"
-    sudo curl -sSL -H 'Cache-Control: no-cache' "$STARTUP_SCRIPT_URL?$(date +%s)" -o /opt/startup.sh
-    sudo chmod 755 /opt/startup.sh
+    # Create environment file with variables
+    echo_info "Creating environment file for oneshot service"
+    echo "INST_USER=${INST_USER}" | sudo tee "$ENV_FILE" > /dev/null
+    echo "INST_DRIVER=${INST_DRIVER}" | sudo tee -a "$ENV_FILE" > /dev/null
+    echo "INST_METRICS_VARS='${INST_METRICS_VARS}'" | sudo tee -a "$ENV_FILE" > /dev/null
+    echo "IMAGE_LIST_JSON='${IMAGE_LIST_JSON}'" | sudo tee -a "$ENV_FILE" > /dev/null
+    echo "GCS_BUCKET=${GCS_BUCKET}" | sudo tee -a "$ENV_FILE" > /dev/null
+    sudo chmod 600 "$ENV_FILE"
     
     # Create service file
-    echo_info "Creating systemd service file"
+    echo_info "Creating systemd service file for oneshot service"
     cat << EOF | sudo tee "$SERVICE_FILE" > /dev/null
 [Unit]
 Description=Instance Oneshot Configuration
-After=network-online.target lifecycle-script.service
+After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=oneshot
-EnvironmentFile=${env_file}
-ExecStart=/opt/startup.sh \${INST_USER} \${INST_DRIVER} "\${INST_METRICS_VARS}"
+EnvironmentFile=/etc/systemd/system/${SERVICE_NAME}.env
+ExecStart=$SCRIPTS_DIR/startup.sh \${INST_USER} \${INST_DRIVER} \${INST_METRICS_VARS} \${IMAGE_LIST_JSON} \${GCS_BUCKET}
 StandardOutput=journal
 StandardError=journal
-KillMode=process
-TimeoutStartSec=0
-TimeoutStopSec=180s
 RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target
 EOF
-    sudo chmod 644 "$SERVICE_FILE"
     
     # Reload systemd, enable and start the service
     echo_info "Reloading systemd configuration"
@@ -146,70 +336,50 @@ EOF
     echo_info "Enabling and starting $SERVICE_NAME service"
     sudo systemctl enable "$SERVICE_NAME"
     sudo systemctl start "$SERVICE_NAME"
-}
-
-# Stream service logs
-stream_logs() {
-    echo_info "Streaming service logs..."
-    sudo journalctl -f -u "$SERVICE_NAME" --no-pager &
-    JOURNAL_PID=$!
     
-    # Wait for service to complete or fail with timeout
-    local timeout=600  # 10 minutes timeout
-    local elapsed=0
-    local check_interval=5
-    
-    echo_info "Monitoring service status (timeout: ${timeout}s)..."
-    while [ $elapsed -lt $timeout ]; do
-        # Check if service is still active
-        if ! systemctl is-active --quiet "$SERVICE_NAME"; then
-            echo_info "Service is no longer active, checking final status"
-            break
-        fi
-        
-        # Check if service is still running but in a different state
-        local status=$(systemctl show -p ActiveState --value "$SERVICE_NAME")
-        if [ "$status" != "active" ]; then
-            echo_info "Service state changed to: $status"
-            break
-        fi
-        
-        sleep $check_interval
-        elapsed=$((elapsed + check_interval))
-        
-        # Show progress every minute
-        if [ $((elapsed % 60)) -eq 0 ]; then
-            echo_info "Still waiting for service to complete... (${elapsed}s elapsed)"
-        fi
-    done
-    
-    # Kill the journalctl process
-    kill $JOURNAL_PID 2>/dev/null
-    wait $JOURNAL_PID 2>/dev/null
-    
-    # Check if we timed out
-    if [ $elapsed -ge $timeout ]; then
-        echo_error "Monitoring timed out after ${timeout}s. Service may still be running."
-        echo_info "You can check status manually with: sudo systemctl status $SERVICE_NAME"
-        return
+    # Check service status
+    echo_info "Checking service status"
+    if ! systemctl is-active "$SERVICE_NAME" > /dev/null 2>&1; then
+        echo_error "Service failed to start. Check logs for details."
+        echo_info "To view logs, run: sudo journalctl -u $SERVICE_NAME"
+        return 1
     fi
     
-    # Check final status
-    if systemctl is-failed --quiet "$SERVICE_NAME"; then
-        echo_error "Service failed to complete successfully"
-        sudo systemctl status "$SERVICE_NAME"
-    else
-        echo_info "Service completed successfully"
-    fi
-    
+    echo_info "Service started successfully"
     echo_info "To view complete logs at any time, run: sudo journalctl -u $SERVICE_NAME"
 }
 
-# Main execution flow
+
+# Main function
 main() {
-    # Initialize logging
+    # Initialize log file
     init_log_file
+    
     echo_info "Starting instance bootstrap oneshot script"
+    
+    # Print startup information
+    echo_info "User: $INST_USER"
+    echo_info "Image List: $IMAGE_LIST_JSON"
+    echo_info "GCS Bucket: $GCS_BUCKET"
+    echo_info "Repository URL: $REPO_URL"
+    echo_info "Repository Branch: $REPO_BRANCH"
+    
+    # Clone repository and stage scripts if URL is provided
+    if [ -n "$REPO_URL" ]; then
+        clone_and_stage_scripts "$REPO_URL" "$REPO_BRANCH"
+    fi
+    
+    # Setup image prestaging service first to allow it to run in the background
+    if ! is_prestage_service_configured; then
+        if [ "$IMAGE_LIST_JSON" != "[]" ]; then
+            echo_info "Setting up image prestaging service"
+            setup_prestage_service
+        else
+            echo_info "No images specified for prestaging. Skipping prestage service setup."
+        fi
+    else
+        echo_info "Image prestaging service is already configured. Skipping configuration."
+    fi
     
     # Check if service already exists and is running/completed
     if check_service_status; then
@@ -218,7 +388,7 @@ main() {
         echo_info "Service status details:"
         systemctl show "$SERVICE_NAME" -p LoadState,ActiveState,SubState,UnitFileState,Result
         echo_info "Instance bootstrap oneshot script completed - service already configured"
-        exit 0
+        return 0
     else
         # Stop and disable service if it exists but failed
         if systemctl list-unit-files "$SERVICE_NAME.service" | grep -q "$SERVICE_NAME"; then
@@ -230,15 +400,12 @@ main() {
             sudo systemctl reset-failed "$SERVICE_NAME" 2>/dev/null || true
         fi
         
-        # Setup and start service
+        # Setup oneshot service
         setup_service
-        
-        ## Disable log streaming
-        ## stream_logs
     fi
     
-    echo_info "Instance bootstrap oneshot script completed"
-    exit 0
+    echo_info "Oneshot configuration completed successfully"
+    return 0
 }
 
 # Execute main function

--- a/oneshot.sh
+++ b/oneshot.sh
@@ -293,8 +293,12 @@ setup_prestage_service() {
     # Create environment file with variables
     echo_info "Creating environment file for prestaging service"
     echo "INST_USER=${INST_USER}" | sudo tee "$PRESTAGE_ENV_FILE" > /dev/null
-    # Ensure JSON is properly quoted in the environment file
-    echo "IMAGE_LIST_JSON='${IMAGE_LIST_JSON}'" | sudo tee -a "$PRESTAGE_ENV_FILE" > /dev/null
+    
+    # Handle JSON properly - strip any outer quotes first, then add them consistently
+    # This prevents double-quoting issues when the variable is expanded in the service
+    local cleaned_json=$(echo "$IMAGE_LIST_JSON" | sed "s/^'\\(.*\\)'$/\\1/")
+    echo "IMAGE_LIST_JSON='${cleaned_json}'" | sudo tee -a "$PRESTAGE_ENV_FILE" > /dev/null
+    
     echo "GCS_BUCKET=${GCS_BUCKET}" | sudo tee -a "$PRESTAGE_ENV_FILE" > /dev/null
     sudo chmod 600 "$PRESTAGE_ENV_FILE"
     

--- a/oneshot.sh
+++ b/oneshot.sh
@@ -11,10 +11,11 @@ INST_METRICS_VARS="$3"
 # Pass the image list as a JSON string
 IMAGE_LIST_JSON=${4:-'["nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12"]'}
 # GCS bucket for image storage
-GCS_BUCKET=${5:-"docker-images-prestage"}
+GCS_BUCKET=${5:-"brev-image-prestage"}
 # Repository URL and branch for cloning
-REPO_URL=${6:-"https://github.com/project-gnr8/instance-bootstrap.git"}
-REPO_BRANCH=${7:-"main"}
+REPO_BRANCH=${6:-"main"}
+REPO_URL="https://github.com/project-gnr8/instance-bootstrap.git"
+
 
 # Define constants
 SERVICE_NAME="instance-oneshot"

--- a/oneshot.sh
+++ b/oneshot.sh
@@ -93,50 +93,38 @@ echo_success() {
 install_required_packages() {
     echo_info "Installing required packages for all scripts"
     
-    # Create a list of packages to install
-    local packages=(
-        git
-        curl
-        jq
-        aria2
+    # Define packages and their corresponding commands
+    declare -A pkg_commands=(
+        ["git"]="git"
+        ["curl"]="curl"
+        ["jq"]="jq"
+        ["aria2"]="aria2c"
     )
     
     # Check which packages are already installed
     local packages_to_install=()
-    for pkg in "${packages[@]}"; do
-        if ! command -v "$pkg" &>/dev/null; then
+    for pkg in "${!pkg_commands[@]}"; do
+        if ! command -v "${pkg_commands[$pkg]}" &>/dev/null; then
             packages_to_install+=("$pkg")
         else
-            echo_info "$pkg is already installed"
+            echo_info "${pkg_commands[$pkg]} is already installed"
         fi
     done
     
     # Install missing packages if any
     if [ ${#packages_to_install[@]} -gt 0 ]; then
         echo_info "Installing packages: ${packages_to_install[*]}"
-        sudo apt-get update -y > /dev/null
-        sudo apt-get install -y "${packages_to_install[@]}" > /dev/null
-        
-        # Verify installation
-        local failed=0
-        for pkg in "${packages_to_install[@]}"; do
-            if ! command -v "$pkg" &>/dev/null; then
-                echo_error "Failed to install $pkg"
-                failed=1
-            else
-                echo_success "$pkg installed successfully"
-            fi
-        done
-        
-        if [ $failed -eq 1 ]; then
-            echo_error "Some packages failed to install"
+        if sudo apt-get update -y > /dev/null && 
+           sudo apt-get install -y "${packages_to_install[@]}" > /dev/null; then
+            echo_success "Package installation completed successfully"
+        else
+            echo_error "Failed to install some packages"
             return 1
         fi
     else
         echo_info "All required packages are already installed"
     fi
     
-    echo_success "Package installation completed"
     return 0
 }
 

--- a/oneshot.sh
+++ b/oneshot.sh
@@ -319,7 +319,19 @@ setup_prestage_service() {
     
     # Copy systemd service file
     echo_info "Installing systemd service file"
-    sudo cp "$PRESTAGE_SERVICE_FILE" "/etc/systemd/system/${PRESTAGE_SERVICE_NAME}.service"
+    if [ ! -f "$SCRIPTS_DIR/docker-image-prestage.service" ]; then
+        echo_error "Service file not found: $SCRIPTS_DIR/docker-image-prestage.service"
+        return 1
+    fi
+    
+    # Copy from the current directory
+    sudo cp "$SCRIPTS_DIR/docker-image-prestage.service" "/etc/systemd/system/${PRESTAGE_SERVICE_NAME}.service"
+    
+    # Verify the service file was copied successfully
+    if [ ! -f "/etc/systemd/system/${PRESTAGE_SERVICE_NAME}.service" ]; then
+        echo_error "Failed to copy service file to /etc/systemd/system/"
+        return 1
+    fi
     
     # Reload systemd to pick up the new service
     echo_info "Reloading systemd daemon"

--- a/startup.sh
+++ b/startup.sh
@@ -140,7 +140,8 @@ install_metrics() {
     
     # The metrics script expects individual space-separated arguments
     # We need to pass them directly to bash -s without any array processing
-    curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup.sh | \
+    # curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/main/setup.sh | \
+    curl -sSL https://raw.githubusercontent.com/Shiftius/ansible-gpu-metrics-collector/feat-telegraf-procstat/setup.sh | \
         bash -s -- $INST_METRICS_VARS
     
     echo_info "Metrics setup completed"

--- a/utils/upload-images.sh
+++ b/utils/upload-images.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+GCS_BUCKET=${1:-"brev-image-prestage"}
+
+# Configure parallel downloads
+# Use more threads for faster downloads
+PARALLEL_THREADS=16
+# Use more processes for parallel downloads
+PARALLEL_PROCESSES=8
+# Set higher sliced download threshold for large files (50MB)
+SLICED_OBJECT_THRESHOLD=50M
+
+# Make sure GCS_BUCKET is set in your environment
+if [ -z "$GCS_BUCKET" ]; then
+  echo "GCS_BUCKET variable is not set."
+  exit 1
+fi
+
+# Define the list of images
+# images=(
+#   "nvcr.io/nvidia/rapidsai/notebooks:24.12-cuda12.5-py3.12"
+#   "nvcr.io/nvidia/clara/clara-parabricks:4.4.0-1"
+#   "nvcr.io/nvidia/nemo:24.12"
+#   "egalinkin/demo"
+# )
+
+images=(
+  "nvcr.io/nvidia/nemo:24.12"
+  "egalinkin/demo"
+)
+
+docker logout nvcr.io
+
+# Pull each Docker image
+for image in "${images[@]}"; do
+  echo "Pulling image: $image"
+  docker pull "$image"
+done
+
+# Save each image to a tarball. We replace '/' and ':' with '__' to generate a filesystem-safe filename.
+for image in "${images[@]}"; do
+  safe_name=$(echo "$image" | tr '/:' '__')
+  tar_file="${safe_name}.tar"
+  echo "Saving image $image to ${tar_file}"
+  docker save "$image" -o "$tar_file"
+done
+
+# Create a destination folder path within the bucket
+destination="gs://${GCS_BUCKET}/"
+
+# Upload tar files in parallel using gsutil's -m flag for multi-threading.
+# You can also tweak additional parallel settings if needed.
+echo "Uploading tar files to ${destination}"
+gsutil -o "GSUtil:parallel_thread_count=$PARALLEL_THREADS" \
+    -o "GSUtil:parallel_process_count=$PARALLEL_PROCESSES" \
+    -o "GSUtil:sliced_object_download_threshold=$SLICED_OBJECT_THRESHOLD" \
+    -m cp *.tar "${destination}"


### PR DESCRIPTION
- Kickoff image prestaging in the background, continue other instance startup automation, and write out a status file when images are ready
- Avoid registry rate limiting and waiting for docker client initialization: support downloading tarball(s) via parallel threads and processes using gsutil or even aria2c
- Stage image via `docker load`